### PR TITLE
Add ridge regression baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # polymer-performance-prediction
-Placeholder.
+
+This repository provides a minimal baseline for the **NeurIPS - Open Polymer Prediction 2025** Kaggle competition.
+
+The `baseline.py` script trains a ridge regression model using only numeric features and
+creates a submission file.
+
+## Usage
+
+```bash
+python baseline.py --train path/to/train.csv --test path/to/test.csv --output submission.csv
+```
+
+By default it expects `id` and `target` columns. The predictions will be written to
+`submission.csv` in the required Kaggle format.
+

--- a/baseline.py
+++ b/baseline.py
@@ -1,0 +1,55 @@
+import argparse
+from pathlib import Path
+
+import pandas as pd
+from sklearn.linear_model import Ridge
+
+
+def train_ridge_and_predict(train_path: str,
+                            test_path: str,
+                            output_path: str = "submission.csv",
+                            target_column: str = "target",
+                            id_column: str = "id",
+                            alpha: float = 1.0) -> pd.DataFrame:
+    """Train a ridge regression model and generate predictions.
+
+    Only numeric feature columns present in both train and test are used.
+    The resulting predictions are saved to ``output_path``.
+    """
+    train_df = pd.read_csv(train_path)
+    test_df = pd.read_csv(test_path)
+
+    feature_cols = [c for c in train_df.columns if c not in {target_column, id_column}]
+    feature_cols = [c for c in feature_cols if pd.api.types.is_numeric_dtype(train_df[c])]
+    X_train = train_df[feature_cols]
+    y_train = train_df[target_column]
+    X_test = test_df[feature_cols]
+
+    model = Ridge(alpha=alpha, random_state=0)
+    model.fit(X_train, y_train)
+    predictions = model.predict(X_test)
+
+    submission = pd.DataFrame({id_column: test_df[id_column], target_column: predictions})
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    submission.to_csv(output_path, index=False)
+    return submission
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Baseline for Open Polymer Prediction 2025")
+    parser.add_argument("--train", required=True, help="Path to training CSV")
+    parser.add_argument("--test", required=True, help="Path to test CSV")
+    parser.add_argument("--output", default="submission.csv", help="Where to write predictions")
+    parser.add_argument("--target", default="target", help="Name of target column")
+    parser.add_argument("--id", dest="id_column", default="id", help="Name of ID column")
+    parser.add_argument("--alpha", type=float, default=1.0, help="Ridge regularization strength")
+    args = parser.parse_args()
+    train_ridge_and_predict(
+        train_path=args.train,
+        test_path=args.test,
+        output_path=args.output,
+        target_column=args.target,
+        id_column=args.id_column,
+        alpha=args.alpha,
+    )
+

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -1,0 +1,80 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pandas as pd
+import numpy as np
+
+from baseline import train_ridge_and_predict
+
+
+def test_ridge_baseline_creates_prediction_file(tmp_path):
+    """Given simple numeric data, predictions file is created with expected values."""
+    train_df = pd.DataFrame({
+        "id": [1, 2, 3, 4],
+        "feature1": [1, 2, 3, 4],
+        "feature2": [0.1, 0.2, 0.3, 0.4],
+    })
+    train_df["target"] = 2 * train_df["feature1"] + 0.5 * train_df["feature2"]
+
+    test_df = pd.DataFrame({
+        "id": [5, 6],
+        "feature1": [5, 6],
+        "feature2": [0.5, 0.6],
+    })
+
+    train_path = tmp_path / "train.csv"
+    test_path = tmp_path / "test.csv"
+    train_df.to_csv(train_path, index=False)
+    test_df.to_csv(test_path, index=False)
+    output_path = tmp_path / "pred.csv"
+
+    preds = train_ridge_and_predict(
+        train_path=str(train_path),
+        test_path=str(test_path),
+        output_path=str(output_path),
+        alpha=0.0,  # makes linear regression for deterministic results
+    )
+
+    assert output_path.exists()
+    loaded = pd.read_csv(output_path)
+    assert len(loaded) == len(test_df)
+    np.testing.assert_allclose(
+        loaded["target"],
+        2 * test_df["feature1"] + 0.5 * test_df["feature2"],
+        rtol=1e-5,
+    )
+    assert list(loaded.columns) == ["id", "target"]
+
+
+def test_ridge_baseline_ignores_non_numeric_columns(tmp_path):
+    """Given categorical columns, they are ignored during training."""
+    train_df = pd.DataFrame({
+        "id": [1, 2, 3, 4],
+        "feature1": [1.0, 2.0, 3.0, 4.0],
+        "category": ["a", "b", "c", "d"],
+    })
+    train_df["target"] = 3 * train_df["feature1"]
+
+    test_df = pd.DataFrame({
+        "id": [5, 6],
+        "feature1": [5.0, 6.0],
+        "category": ["e", "f"],
+    })
+
+    train_path = tmp_path / "train.csv"
+    test_path = tmp_path / "test.csv"
+    train_df.to_csv(train_path, index=False)
+    test_df.to_csv(test_path, index=False)
+
+    output_path = tmp_path / "pred.csv"
+    preds = train_ridge_and_predict(
+        train_path=str(train_path),
+        test_path=str(test_path),
+        output_path=str(output_path),
+        alpha=0.0,
+    )
+    expected = 3 * test_df["feature1"]
+    np.testing.assert_allclose(preds["target"], expected, rtol=1e-5)
+


### PR DESCRIPTION
## Summary
- create baseline ridge regression script for Open Polymer Prediction 2025
- add tests covering baseline functionality
- document baseline usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6f942de08325a997e706d43a0893