### PR TITLE
Add Kaggle defaults for baseline CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ creates a submission file.
 ## Usage
 
 ```bash
-python baseline.py --train path/to/train.csv --test path/to/test.csv --output submission.csv
+python baseline.py
 ```
 
-By default it expects `id` and `target` columns. The predictions will be written to
-`submission.csv` in the required Kaggle format.
+When executed inside Kaggle, the script automatically reads the competition
+data from `/kaggle/input/neurips-open-polymer-prediction-2025/` and writes the
+submission file to `/kaggle/working/submission.csv`. If you want to supply
+custom paths, use the `--train`, `--test` and `--output` options.
 

--- a/baseline.py
+++ b/baseline.py
@@ -1,6 +1,11 @@
 import argparse
 from pathlib import Path
 
+# Default paths for running inside Kaggle
+DEFAULT_TRAIN_PATH = "/kaggle/input/neurips-open-polymer-prediction-2025/train.csv"
+DEFAULT_TEST_PATH = "/kaggle/input/neurips-open-polymer-prediction-2025/test.csv"
+DEFAULT_OUTPUT_PATH = "/kaggle/working/submission.csv"
+
 import pandas as pd
 from sklearn.linear_model import Ridge
 
@@ -37,9 +42,9 @@ def train_ridge_and_predict(train_path: str,
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Baseline for Open Polymer Prediction 2025")
-    parser.add_argument("--train", required=True, help="Path to training CSV")
-    parser.add_argument("--test", required=True, help="Path to test CSV")
-    parser.add_argument("--output", default="submission.csv", help="Where to write predictions")
+    parser.add_argument("--train", default=DEFAULT_TRAIN_PATH, help="Path to training CSV")
+    parser.add_argument("--test", default=DEFAULT_TEST_PATH, help="Path to test CSV")
+    parser.add_argument("--output", default=DEFAULT_OUTPUT_PATH, help="Where to write predictions")
     parser.add_argument("--target", default="target", help="Name of target column")
     parser.add_argument("--id", dest="id_column", default="id", help="Name of ID column")
     parser.add_argument("--alpha", type=float, default=1.0, help="Ridge regularization strength")


### PR DESCRIPTION
## Summary
- add default dataset paths for Kaggle execution
- update README usage instructions
- test CLI running without arguments using fake Kaggle directories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e7519b9608325b6c32a0357d73c58