### PR TITLE
Add dataset path dataclass and accessor

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,7 +3,16 @@ Centralized configuration for the NeurIPS polymer prediction project.
 """
 import os
 from pathlib import Path
-from typing import Dict, Any, Optional
+from dataclasses import dataclass
+from typing import Dict, Any, Optional, List
+
+
+@dataclass
+class DatasetPaths:
+    train: Path
+    test: Path
+    submission: Path
+    supplementary: List[Path]
 
 
 class EnvironmentConfig:
@@ -25,11 +34,42 @@ class EnvironmentConfig:
             self.data_dir = self.project_root / 'data'
             self.output_dir = self.project_root / 'output'
             self.cv_dir = self.data_dir / 'cv'
-        
+
         # Common paths
         self.train_file = 'train.csv'
         self.test_file = 'test.csv'
         self.sample_submission_file = 'sample_submission.csv'
+
+        path_map = {
+            True: DatasetPaths(
+                train=self.data_dir / self.train_file,
+                test=self.data_dir / self.test_file,
+                submission=self.output_dir / 'submission.csv',
+                supplementary=[
+                    self.data_dir / 'train_supplement/dataset1.csv',
+                    self.data_dir / 'train_supplement/dataset2.csv',
+                    self.data_dir / 'train_supplement/dataset3.csv',
+                    self.data_dir / 'train_supplement/dataset4.csv',
+                    Path('/kaggle/input/extra-dataset-with-smilestgpidpolimers-class/TgSS_enriched_cleaned.csv'),
+                    Path('/kaggle/input/polymer-tg-density-excerpt/tg_density.csv')
+                ]
+            ),
+            False: DatasetPaths(
+                train=self.data_dir / 'raw/train.csv',
+                test=self.data_dir / 'raw/test.csv',
+                submission=self.output_dir / 'submission.csv',
+                supplementary=[
+                    self.data_dir / 'raw/train_supplement/dataset1.csv',
+                    self.data_dir / 'raw/train_supplement/dataset2.csv',
+                    self.data_dir / 'raw/train_supplement/dataset3.csv',
+                    self.data_dir / 'raw/train_supplement/dataset4.csv',
+                    self.data_dir / 'raw/extra_datasets/TgSS_enriched_cleaned.csv',
+                    self.data_dir / 'raw/extra_datasets/tg_density.csv'
+                ]
+            )
+        }
+
+        self.dataset_paths = path_map[self.is_kaggle]
     
     def _setup_model_params(self):
         """Setup model parameters based on environment."""
@@ -82,6 +122,10 @@ class EnvironmentConfig:
     def get_data_path(self, filename: str) -> Path:
         """Get full path for a data file."""
         return self.data_dir / filename
+
+    def get_dataset_paths(self) -> DatasetPaths:
+        """Return dataset paths for current environment."""
+        return self.dataset_paths
     
     def get_cv_path(self, fold: int) -> Dict[str, Path]:
         """Get CV fold paths."""

--- a/model.py
+++ b/model.py
@@ -68,37 +68,10 @@ if not config.is_kaggle:
 
 # Already checked above
 
-# Set paths based on environment
-if config.is_kaggle:
-    # Kaggle competition paths
-    TRAIN_PATH = config.data_dir / 'train.csv'
-    TEST_PATH = config.data_dir / 'test.csv'
-    SUBMISSION_PATH = config.output_dir / 'submission.csv'
-    
-    # Supplementary dataset paths
-    SUPP_PATHS = [
-        config.data_dir / 'train_supplement/dataset1.csv',
-        config.data_dir / 'train_supplement/dataset2.csv',
-        config.data_dir / 'train_supplement/dataset3.csv',
-        '/kaggle/input/neurips-open-polymer-prediction-2025/train_supplement/dataset4.csv',
-        '/kaggle/input/extra-dataset-with-smilestgpidpolimers-class/TgSS_enriched_cleaned.csv',
-        '/kaggle/input/polymer-tg-density-excerpt/tg_density.csv'
-    ]
-else:
-    # Local paths
-    TRAIN_PATH = 'data/raw/train.csv'
-    TEST_PATH = 'data/raw/test.csv'
-    SUBMISSION_PATH = 'output/submission.csv'
-    
-    # Supplementary dataset paths
-    SUPP_PATHS = [
-        'data/raw/train_supplement/dataset1.csv',
-        'data/raw/train_supplement/dataset2.csv',
-        'data/raw/train_supplement/dataset3.csv',
-        'data/raw/train_supplement/dataset4.csv',
-        'data/raw/extra_datasets/TgSS_enriched_cleaned.csv',
-        'data/raw/extra_datasets/tg_density.csv'
-    ]
+# Set dataset paths
+paths = config.get_dataset_paths()
+TRAIN_PATH, TEST_PATH, SUBMISSION_PATH = paths.train, paths.test, paths.submission
+SUPP_PATHS = paths.supplementary
 
 # Target columns
 TARGETS = ['Tg', 'FFV', 'Tc', 'Density', 'Rg']


### PR DESCRIPTION
## Summary
- centralize dataset file paths in a DatasetPaths dataclass
- retrieve dataset paths via EnvironmentConfig accessor
- use new path accessor in model setup

## Testing
- `pytest tests/test_data_integration.py`

------
https://chatgpt.com/codex/tasks/task_b_68b800bf9e7c83309a46e142c1a124f3