### PR TITLE
Centralize target column names in constants module

### DIFF
--- a/data_helpers.py
+++ b/data_helpers.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from typing import Tuple, Optional, Dict, Any
 from config import CONFIG
 
+from src.constants import TARGET_COLUMNS
+
 
 def load_raw_data(data_type: str = 'train') -> pd.DataFrame:
     """
@@ -86,7 +88,7 @@ def split_features_targets(df: pd.DataFrame,
         Tuple of (features_df, targets_df)
     """
     if target_cols is None:
-        target_cols = ['Tg', 'FFV', 'Tc', 'Density', 'Rg']
+        target_cols = TARGET_COLUMNS
     
     # Find available target columns
     available_targets = [col for col in target_cols if col in df.columns]
@@ -235,7 +237,7 @@ def get_data_stats(df: pd.DataFrame) -> Dict[str, Any]:
     }
     
     # Check for target columns
-    target_cols = ['Tg', 'FFV', 'Tc', 'Density', 'Rg']
+    target_cols = TARGET_COLUMNS
     available_targets = [col for col in target_cols if col in df.columns]
     
     if available_targets:

--- a/data_processing.py
+++ b/data_processing.py
@@ -18,6 +18,8 @@ from sklearn.decomposition import PCA
 from sklearn.cross_decomposition import PLSRegression
 from tqdm import tqdm
 
+from src.constants import TARGET_COLUMNS
+
 import keras
 from keras.models import Sequential, Model
 from keras.layers import Dense, Input
@@ -901,7 +903,7 @@ def load_competition_data(train_path, test_path, supp_paths=None, use_supplement
     original_count = len(train_df)
     
     # Count non-null target values for each row
-    target_columns = ['Tg', 'FFV', 'Tc', 'Density', 'Rg']
+    target_columns = TARGET_COLUMNS
     train_df['target_count'] = train_df[target_columns].notna().sum(axis=1)
     
     # Sort by target_count (descending) and new_sim (True first) to prioritize rows with more data

--- a/model.py
+++ b/model.py
@@ -19,6 +19,8 @@ import sys
 import os
 import math
 
+from src.constants import TARGET_COLUMNS
+
 # Import data processing functions
 from data_processing import (
     calculate_main_branch_atoms,
@@ -74,7 +76,7 @@ TRAIN_PATH, TEST_PATH, SUBMISSION_PATH = paths.train, paths.test, paths.submissi
 SUPP_PATHS = paths.supplementary
 
 # Target columns
-TARGETS = ['Tg', 'FFV', 'Tc', 'Density', 'Rg']
+TARGETS = TARGET_COLUMNS
 
 def main(cv_only=False, use_supplementary=True, model_type='lightgbm', run_residual_analysis=False):
     """
@@ -108,7 +110,7 @@ def main(cv_only=False, use_supplementary=True, model_type='lightgbm', run_resid
     X_test = prepare_features(test_df)
     
     # Prepare target variables
-    target_columns = ['Tg', 'FFV', 'Tc', 'Density', 'Rg']
+    target_columns = TARGET_COLUMNS
     y_train = train_df[target_columns]
     
     # Print feature statistics

--- a/scripts/visualize_lgbm_trees.py
+++ b/scripts/visualize_lgbm_trees.py
@@ -22,6 +22,8 @@ from model import (
     prepare_features, select_features_for_target
 )
 
+from src.constants import TARGET_COLUMNS
+
 def format_tree_node(node, feature_names, depth=0, max_depth=5):
     """Format tree node in human-readable format"""
     indent = "  " * depth
@@ -83,7 +85,7 @@ def train_and_visualize_final_trees():
     X_test = prepare_features(test_df)
     
     # Prepare target variables
-    target_columns = ['Tg', 'FFV', 'Tc', 'Density', 'Rg']
+    target_columns = TARGET_COLUMNS
     y_train = train_df[target_columns]
     
     # LightGBM parameters

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,4 @@
+"""Project-wide constants."""
+
+TARGET_COLUMNS = ['Tg', 'FFV', 'Tc', 'Density', 'Rg']
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,8 @@ from pathlib import Path
 parent_dir = Path(__file__).parent.parent
 sys.path.insert(0, str(parent_dir))
 
+from src.constants import TARGET_COLUMNS
+
 
 @pytest.fixture(scope="session")
 def project_root():
@@ -73,7 +75,7 @@ def mock_model_params():
 @pytest.fixture
 def target_columns():
     """Target column names."""
-    return ['Tg', 'FFV', 'Tc', 'Density', 'Rg']
+    return TARGET_COLUMNS
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_data_integration.py
+++ b/tests/test_data_integration.py
@@ -9,6 +9,7 @@ parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, parent_dir)
 
 from data_processing import load_competition_data
+from src.constants import TARGET_COLUMNS
 
 @pytest.fixture
 def data_paths():
@@ -128,7 +129,7 @@ def test_data_consistency(data_paths):
     assert 'SMILES' in train_df.columns, "Should have SMILES column"
     
     # Check that dataframe has target columns
-    target_cols = ['Tg', 'FFV', 'Tc', 'Density', 'Rg']
+    target_cols = TARGET_COLUMNS
     for col in target_cols:
         assert col in train_df.columns, f"Should have {col} column"
     

--- a/tests/test_transformer_refactored.py
+++ b/tests/test_transformer_refactored.py
@@ -5,6 +5,8 @@ import pytest
 import numpy as np
 from unittest.mock import patch, MagicMock
 
+from src.constants import TARGET_COLUMNS
+
 
 class TestSMILESTokenizer:
     """Test suite for SMILESTokenizer."""
@@ -143,7 +145,7 @@ class TestIntegration:
         
         # Prepare data
         X = sample_dataframe['SMILES'].values
-        y = sample_dataframe[['Tg', 'FFV', 'Tc', 'Density', 'Rg']].values
+        y = sample_dataframe[TARGET_COLUMNS].values
         
         # Train model
         model.fit(X, y, epochs=1, batch_size=2, verbose=0)


### PR DESCRIPTION
## Summary
- add `src/constants.py` to hold `TARGET_COLUMNS`
- replace repeated target lists in core modules, tests, and visualization script with imported constant

## Testing
- `pytest tests/` *(fails: SMILESTokenizer missing `use_deepchem` argument)*

------
https://chatgpt.com/codex/tasks/task_b_68b810f51dac83308805f623a1072332