### PR TITLE
Centralize dimensionality reduction flags in config

### DIFF
--- a/config.py
+++ b/config.py
@@ -150,7 +150,7 @@ class EnvironmentConfig:
 
 class DimensionalityReductionConfig:
     """Configuration for dimensionality reduction methods."""
-    
+
     # Available methods
     METHODS = {
         'none': None,
@@ -159,16 +159,25 @@ class DimensionalityReductionConfig:
         'umap': 'UMAP',
         'tsne': 't-SNE'
     }
-    
-    def __init__(self, method: str = 'pca'):
+
+    def __init__(
+        self,
+        method: str = 'pca',
+        use_autoencoder: bool = False,
+        use_pls: bool = False,
+        pca_variance_threshold: Optional[float] = 0.99999,
+    ):
         self.method = method
+        self.use_autoencoder = use_autoencoder
+        self.use_pls = use_pls
+        self.pca_variance_threshold = pca_variance_threshold
         self.params = self._get_method_params(method)
-    
+
     def _get_method_params(self, method: str) -> Dict[str, Any]:
         """Get parameters for specific method."""
         params_map = {
             'pca': {
-                'variance_threshold': 0.99999,
+                'variance_threshold': self.pca_variance_threshold,
                 'n_components': None  # Determined by variance threshold
             },
             'autoencoder': {
@@ -189,12 +198,12 @@ class DimensionalityReductionConfig:
             'none': {}
         }
         return params_map.get(method, {})
-    
+
     def get_reducer(self):
         """Get the appropriate dimensionality reducer."""
         if self.method == 'pca':
             from sklearn.decomposition import PCA
-            return PCA(n_components=self.params['variance_threshold'])
+            return PCA(n_components=self.pca_variance_threshold)
         elif self.method == 'autoencoder':
             # Return custom autoencoder class
             return None  # Implemented separately
@@ -210,11 +219,11 @@ class DimensionalityReductionConfig:
             return TSNE(**self.params)
         else:
             return None
-    
+
     def _get_fallback_reducer(self):
         """Get fallback reducer if primary method unavailable."""
         from sklearn.decomposition import PCA
-        return PCA(n_components=0.99999)
+        return PCA(n_components=self.pca_variance_threshold or 0.99999)
 
 
 class ModelRegistry:

--- a/cv.py
+++ b/cv.py
@@ -18,10 +18,7 @@ warnings.filterwarnings('ignore')
 # These imports are conditional based on the main model.py imports
 from src.competition_metric import neurips_polymer_metric
 from src.diagnostics import CVDiagnostics
-from config import LIGHTGBM_PARAMS
-
-# PCA variance threshold - should match the one in model.py
-PCA_VARIANCE_THRESHOLD = None
+from config import CONFIG, LIGHTGBM_PARAMS
 
 
 def perform_cross_validation(X, y, cv_folds=5, target_columns=None, enable_diagnostics=True, random_seed=42, model_type='lightgbm', preprocessed=True):
@@ -120,8 +117,11 @@ def perform_cross_validation(X, y, cv_folds=5, target_columns=None, enable_diagn
                         
                         # Apply PCA if enabled
                         pca = None
-                        if PCA_VARIANCE_THRESHOLD is not None:
-                            pca = PCA(n_components=PCA_VARIANCE_THRESHOLD, random_state=random_seed)
+                        if CONFIG.dim_reduction.pca_variance_threshold is not None:
+                            pca = PCA(
+                                n_components=CONFIG.dim_reduction.pca_variance_threshold,
+                                random_state=random_seed,
+                            )
                             X_target_pca = pca.fit_transform(X_target_scaled)
                             X_target_final = X_target_pca
                         else:

--- a/model.py
+++ b/model.py
@@ -37,21 +37,15 @@ import warnings
 warnings.filterwarnings('ignore')
 
 # Import configuration
-from config import EnvironmentConfig
+from config import CONFIG, LIGHTGBM_PARAMS
 from residual_analysis import ResidualAnalyzer
-config = EnvironmentConfig()
+config = CONFIG
 
 # Dimensionality reduction settings (only one method should be enabled at a time)
-# PCA variance threshold - set to None to disable PCA
-PCA_VARIANCE_THRESHOLD = 0.99999
-
-# Autoencoder settings - set to True to use autoencoder instead of PCA
-USE_AUTOENCODER = False
 AUTOENCODER_LATENT_DIM = 32  # Number of latent dimensions
 EPOCHS = 20
 
-# PLS settings - set to True to use PLS instead of PCA/autoencoder
-USE_PLS = False  # Whether to use PLS for dimensionality reduction
+# PLS settings
 PLS_N_COMPONENTS = 86  # Number of PLS components
 
 # Transformer settings - set to True to add transformer features
@@ -63,7 +57,6 @@ if not config.is_kaggle:
     from src.competition_metric import neurips_polymer_metric
     from src.diagnostics import CVDiagnostics
     from cv import perform_cross_validation, perform_multi_seed_cv
-    from config import LIGHTGBM_PARAMS
 
 
 # Already checked above
@@ -89,7 +82,12 @@ def main(cv_only=False, use_supplementary=True, model_type='lightgbm', run_resid
     print(f"=== Separate {model_type.upper()} Models for Polymer Prediction ===")
     
     # Validate dimensionality reduction settings
-    dim_reduction_methods = sum([USE_AUTOENCODER, USE_PLS, PCA_VARIANCE_THRESHOLD is not None])
+    dr_cfg = config.dim_reduction
+    dim_reduction_methods = sum([
+        dr_cfg.use_autoencoder,
+        dr_cfg.use_pls,
+        dr_cfg.pca_variance_threshold is not None,
+    ])
     if dim_reduction_methods > 1:
         raise ValueError("Only one dimensionality reduction method should be enabled at a time")
     
@@ -130,18 +128,19 @@ def main(cv_only=False, use_supplementary=True, model_type='lightgbm', run_resid
     
     # Apply preprocessing using imported function
     X_train_preprocessed, X_test_preprocessed = preprocess_data(
-        X_train, X_test, 
-        use_autoencoder=USE_AUTOENCODER,
+        X_train,
+        X_test,
+        use_autoencoder=dr_cfg.use_autoencoder,
         autoencoder_latent_dim=AUTOENCODER_LATENT_DIM,
-        pca_variance_threshold=PCA_VARIANCE_THRESHOLD,
-        use_pls=USE_PLS,
+        pca_variance_threshold=dr_cfg.pca_variance_threshold,
+        use_pls=dr_cfg.use_pls,
         pls_n_components=PLS_N_COMPONENTS,
         y_train=y_train,
         epochs=EPOCHS,
         use_transformer=USE_TRANSFORMER,
         transformer_latent_dim=TRANSFORMER_LATENT_DIM,
         smiles_train=train_df['SMILES'],
-        smiles_test=test_df['SMILES']
+        smiles_test=test_df['SMILES'],
     )
     
     # Run cross-validation if requested (but not on Kaggle)
@@ -350,7 +349,7 @@ def main(cv_only=False, use_supplementary=True, model_type='lightgbm', run_resid
                 print(f"Error analyzing transformer residuals: {e}")
         
         # Analyze PCA residuals if enabled
-        if PCA_VARIANCE_THRESHOLD is not None:
+        if dr_cfg.pca_variance_threshold is not None:
             print("\n--- PCA Reconstruction Residuals ---")
             # PCA was applied during preprocessing, we need to get reconstruction error
             # This would require storing the PCA object during preprocessing
@@ -397,9 +396,9 @@ if __name__ == "__main__":
 
     # Check for no dimensionality reduction
     if '--no-dim-reduction' in sys.argv:
-        USE_PLS = False
-        PCA_VARIANCE_THRESHOLD = None
-        USE_AUTOENCODER = False
+        config.dim_reduction.use_pls = False
+        config.dim_reduction.pca_variance_threshold = None
+        config.dim_reduction.use_autoencoder = False
         print("No dimensionality reduction will be used")
     
     main(cv_only=cv_only, use_supplementary=not no_supplement, model_type=model_type, run_residual_analysis=residual_analysis)

--- a/tests/test_dim_reduction_config.py
+++ b/tests/test_dim_reduction_config.py
@@ -1,0 +1,10 @@
+import pytest
+from config import CONFIG
+
+
+def test_dim_reduction_defaults():
+    """Dimensionality reduction flags should have expected defaults."""
+    dr_cfg = CONFIG.dim_reduction
+    assert dr_cfg.use_autoencoder is False
+    assert dr_cfg.use_pls is False
+    assert dr_cfg.pca_variance_threshold == pytest.approx(0.99999)


### PR DESCRIPTION
## Summary
- Add `use_autoencoder`, `use_pls`, and `pca_variance_threshold` to `DimensionalityReductionConfig`
- Use `CONFIG.dim_reduction` flags in `model.py` and `cv.py`
- Cover default dimensionality-reduction flags with a dedicated test

## Testing
- `pytest tests/` *(fails: SMILESTokenizer unexpected keyword argument 'use_deepchem')*

------
https://chatgpt.com/codex/tasks/task_b_68b81115f54c83309ac67d755721eaa2