### PR TITLE
Refactor seed handling into reusable utility

### DIFF
--- a/data_processing.py
+++ b/data_processing.py
@@ -27,6 +27,8 @@ def ignore_warn(*args, **kwargs):
     pass
 warnings.warn = ignore_warn
 
+from src.utils.seed import set_global_seed
+
 def calculate_main_branch_atoms(smiles):
     """
     Calculate the number of atoms in the main branch of a polymer.
@@ -540,30 +542,7 @@ def apply_autoencoder(X_train, X_test=None, y_train=None, latent_dim=26, epochs=
     
     """
     # Set seeds for reproducibility
-    import numpy as np
-    import random
-    import os
-    
-    # Set all random seeds
-    np.random.seed(random_state)
-    random.seed(random_state)
-    os.environ['PYTHONHASHSEED'] = str(random_state)
-    
-    # Try to import tensorflow and set its seed
-    try:
-        import tensorflow as tf
-        tf.random.set_seed(random_state)
-        # For older versions of tensorflow/keras
-        if hasattr(tf, 'set_random_seed'):
-            tf.set_random_seed(random_state)
-    except ImportError:
-        # If tensorflow not available, try keras backend
-        try:
-            import keras.backend as K
-            if hasattr(K, 'set_random_seed'):
-                K.set_random_seed(random_state)
-        except:
-            pass    
+    set_global_seed(random_state)
     # Define encoder architecture
     input_dim = X_train.shape[1]
     encoder = Sequential([

--- a/src/utils/seed.py
+++ b/src/utils/seed.py
@@ -1,0 +1,27 @@
+import os
+import random
+import numpy as np
+
+try:
+    import tensorflow as tf
+except Exception:  # pragma: no cover
+    tf = None
+
+
+def set_global_seed(seed: int) -> None:
+    """Set random seeds for reproducibility."""
+    np.random.seed(seed)
+    random.seed(seed)
+    if tf is not None:
+        tf.random.set_seed(seed)
+        if hasattr(tf, "set_random_seed"):
+            tf.set_random_seed(seed)
+    try:
+        import keras.backend as K  # type: ignore
+        if hasattr(K, "set_random_seed"):
+            K.set_random_seed(seed)
+    except Exception:
+        pass
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    os.environ["TF_CUDNN_DETERMINISTIC"] = "1"
+    os.environ["TF_DETERMINISTIC_OPS"] = "1"

--- a/tests/test_residual_integration_full.py
+++ b/tests/test_residual_integration_full.py
@@ -9,6 +9,7 @@ import os
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from residual_analysis import ResidualAnalyzer
+from src.utils.seed import set_global_seed
 import warnings
 warnings.filterwarnings('ignore')
 
@@ -17,7 +18,7 @@ def test_residual_analyzer_with_multiple_models():
     analyzer = ResidualAnalyzer()
     
     # Create synthetic data
-    np.random.seed(42)
+    set_global_seed(42)
     n_samples = 100
     y_true = np.random.randn(n_samples)
     

--- a/transformer_model.py
+++ b/transformer_model.py
@@ -2,24 +2,13 @@ import numpy as np
 import tensorflow as tf
 from tensorflow import keras
 from tensorflow.keras import layers
-import random
 import os
 from typing import Optional, Tuple, Union
+from src.utils.seed import set_global_seed
 
 # Force CPU usage
 os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
-
-
-def set_seeds(seed=42):
-    """Set all random seeds for reproducibility."""
-    np.random.seed(seed)
-    random.seed(seed)
-    tf.random.set_seed(seed)
-    os.environ['PYTHONHASHSEED'] = str(seed)
-    os.environ['TF_CUDNN_DETERMINISTIC'] = '1'
-    os.environ['TF_DETERMINISTIC_OPS'] = '1'
-
 
 class SMILESTokenizer:
     """Character-level SMILES tokenizer."""
@@ -98,7 +87,7 @@ class TransformerModel:
         self.model = None
         self.encoder_model = None
         
-        set_seeds(random_state)
+        set_global_seed(random_state)
     
     def _encoder_block(self, inputs):
         """Single transformer encoder block."""
@@ -147,7 +136,7 @@ class TransformerModel:
     
     def build_model(self):
         """Build the transformer encoder-decoder model."""
-        set_seeds(self.random_state)
+        set_global_seed(self.random_state)
         
         # Input: tokenized SMILES sequences
         encoder_inputs = keras.Input(shape=(self.max_length,), dtype=tf.int32, name='smiles_tokens')
@@ -232,7 +221,7 @@ class TransformerModel:
         Returns:
             Training history
         """
-        set_seeds(self.random_state)
+        set_global_seed(self.random_state)
         
         if self.model is None:
             self.build_model()


### PR DESCRIPTION
## Summary
- add `set_global_seed` helper for consistent seeding across modules
- replace scattered seeding logic in transformer model, data pipeline, and tests

## Testing
- `pytest tests/test_transformer_refactored.py`

------
https://chatgpt.com/codex/tasks/task_b_68b811babfd083308ad919c9a6b83c15