### PR TITLE
Refactor autoencoder into supervised encoder

### DIFF
--- a/tests/test_autoencoder_supervised.py
+++ b/tests/test_autoencoder_supervised.py
@@ -1,0 +1,29 @@
+import inspect
+import numpy as np
+import pytest
+import os
+import sys
+
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, parent_dir)
+
+from data_processing import apply_autoencoder
+
+
+def test_apply_autoencoder_signature():
+    sig = inspect.signature(apply_autoencoder)
+    assert 'supervised' not in sig.parameters
+
+
+def test_apply_autoencoder_requires_y_train():
+    X = np.random.rand(4, 3).astype(np.float32)
+    with pytest.raises(ValueError):
+        apply_autoencoder(X)
+
+
+def test_apply_autoencoder_output_shape():
+    X = np.random.rand(10, 4).astype(np.float32)
+    y = np.random.rand(10, 2).astype(np.float32)
+    y[0, 1] = np.nan
+    encoded = apply_autoencoder(X, y_train=y, latent_dim=3, epochs=1, batch_size=5)
+    assert encoded.shape == (10, 3)


### PR DESCRIPTION
## Summary
- remove decoder and unsupervised branch from `apply_autoencoder`
- build encoder→prediction model trained with single MAE loss and sample-weight logic
- add unit tests covering supervised-only interface and encoding output

## Testing
- `pytest tests/test_autoencoder_supervised.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'lightgbm', and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68c51d2fb700833096c6b8c609ad7fc6